### PR TITLE
feat: integrate nytimes api

### DIFF
--- a/src/api/client/nytimesClient.ts
+++ b/src/api/client/nytimesClient.ts
@@ -1,0 +1,33 @@
+import axios from 'axios'
+
+import {
+   parseToNyTimesParams,
+   parseToSingleNyTimesParams,
+   parseToTopStoriesNyTimesParams
+} from '../util/nytimesUtil'
+import { ContentParams } from '@/types'
+import { NYTimesResponse } from '@/types/NyTimesApiTypes'
+
+// list via search
+export const fetchNyTimesEverything = async (params: ContentParams) => {
+   const queryString = parseToNyTimesParams(params)
+   const url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?${queryString}`
+   const response = await axios.get<NYTimesResponse>(url)
+   return response.data
+}
+
+// single item - uses the same api route as /everything with different params
+export const fetchSingleNyTimesArticle = async (id: string) => {
+   const queryString = parseToSingleNyTimesParams(id)
+   const url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?${queryString}`
+   const response = await axios.get<NYTimesResponse>(url)
+   return response.data
+}
+
+// top stories - uses the same api route as /everything due to limited search on 'top-stories'. Uses Today as date.
+export const fetchNyTimesTopStories = async () => {
+   const queryString = parseToTopStoriesNyTimesParams()
+   const url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?${queryString}`
+   const response = await axios.get<NYTimesResponse>(url)
+   return response.data
+}

--- a/src/api/client/nytimesClient.ts
+++ b/src/api/client/nytimesClient.ts
@@ -6,13 +6,13 @@ import {
    parseToTopStoriesNyTimesParams
 } from '../util/nytimesUtil'
 import { ContentParams } from '@/types'
-import { NYTimesResponse } from '@/types/NyTimesApiTypes'
+import { NyTimesResponse } from '@/types/NyTimesApiTypes'
 
 // list via search
-export const fetchNyTimesEverything = async (params: ContentParams) => {
+export const fetchNyTimesSearchContent = async (params: ContentParams) => {
    const queryString = parseToNyTimesParams(params)
    const url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?${queryString}`
-   const response = await axios.get<NYTimesResponse>(url)
+   const response = await axios.get<NyTimesResponse>(url)
    return response.data
 }
 
@@ -20,7 +20,7 @@ export const fetchNyTimesEverything = async (params: ContentParams) => {
 export const fetchSingleNyTimesArticle = async (id: string) => {
    const queryString = parseToSingleNyTimesParams(id)
    const url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?${queryString}`
-   const response = await axios.get<NYTimesResponse>(url)
+   const response = await axios.get<NyTimesResponse>(url)
    return response.data
 }
 
@@ -28,6 +28,6 @@ export const fetchSingleNyTimesArticle = async (id: string) => {
 export const fetchNyTimesTopStories = async () => {
    const queryString = parseToTopStoriesNyTimesParams()
    const url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?${queryString}`
-   const response = await axios.get<NYTimesResponse>(url)
+   const response = await axios.get<NyTimesResponse>(url)
    return response.data
 }

--- a/src/api/queries/usePersonalFeedData.ts
+++ b/src/api/queries/usePersonalFeedData.ts
@@ -3,12 +3,15 @@ import { subDays } from 'date-fns'
 
 import { fetchGuardianContent } from '../client/guardianClient'
 import { fetchNewsApiEverything } from '../client/newsApiClient'
+import { fetchNyTimesSearchContent } from '../client/nytimesClient'
 import { convertGuardianContentToArticle } from '../util/guardianUtil'
 import { convertNewsApiEverythingResToAritcle } from '../util/newsApiUtil'
+import { convertNyTimesSearchResToAritcle } from '../util/nytimesUtil'
 import { queryKeys } from '../util/queryKeys'
 import { Article, ContentParams, ContentResponse, PersonalFeedPreference } from '@/types'
 import { GuardianContentResponse } from '@/types/GuardianApiTypes'
 import { NewApiResponse } from '@/types/NewsApiTypes'
+import { NyTimesResponse as NyTimesResponse } from '@/types/NyTimesApiTypes'
 import { NewsSource, defaultSources } from '@/util/constants'
 
 // basically a category wise parallel search
@@ -41,6 +44,14 @@ export const usePersonalFeedData = ({ sources, categories }: PersonalFeedPrefere
                   queryFn: () => fetchGuardianContent(params),
                   select: (data) =>
                      convertGuardianContentToArticle(data as GuardianContentResponse),
+                  enabled: enabled
+               }
+            case NewsSource.NyTimes:
+               // new york times
+               return {
+                  queryKey: [queryKeys.nytimesPersonalFeed, categories],
+                  queryFn: () => fetchNyTimesSearchContent(params),
+                  select: (data) => convertNyTimesSearchResToAritcle(data as NyTimesResponse),
                   enabled: enabled
                }
 

--- a/src/api/queries/useSearchedNewsData.ts
+++ b/src/api/queries/useSearchedNewsData.ts
@@ -2,12 +2,15 @@ import { UseQueryOptions, useQueries } from '@tanstack/react-query'
 
 import { fetchGuardianContent } from '../client/guardianClient'
 import { fetchNewsApiEverything } from '../client/newsApiClient'
+import { fetchNyTimesSearchContent } from '../client/nytimesClient'
 import { convertGuardianContentToArticle } from '../util/guardianUtil'
 import { convertNewsApiEverythingResToAritcle } from '../util/newsApiUtil'
+import { convertNyTimesSearchResToAritcle } from '../util/nytimesUtil'
 import { queryKeys } from '../util/queryKeys'
 import { Article, ContentParams, ContentResponse } from '@/types'
 import { GuardianContentResponse } from '@/types/GuardianApiTypes'
 import { NewApiResponse } from '@/types/NewsApiTypes'
+import { NyTimesResponse } from '@/types/NyTimesApiTypes'
 import { NewsSource, defaultSources } from '@/util/constants'
 
 export const useSearchedNewsData = (sources: string[], params: ContentParams) => {
@@ -32,6 +35,15 @@ export const useSearchedNewsData = (sources: string[], params: ContentParams) =>
                   queryFn: () => fetchGuardianContent(params),
                   select: (data) =>
                      convertGuardianContentToArticle(data as GuardianContentResponse),
+                  enabled: enabled
+               }
+
+            case NewsSource.NyTimes:
+               // ny times api
+               return {
+                  queryKey: [queryKeys.nytimesContent, params],
+                  queryFn: () => fetchNyTimesSearchContent(params),
+                  select: (data) => convertNyTimesSearchResToAritcle(data as NyTimesResponse),
                   enabled: enabled
                }
 

--- a/src/api/queries/useSingleArticleData.ts
+++ b/src/api/queries/useSingleArticleData.ts
@@ -2,27 +2,45 @@ import { useQuery } from '@tanstack/react-query'
 
 import { fetchSingleGuardianArticle } from '../client/guardianClient'
 import { fetchSingleNewsApiArticle } from '../client/newsApiClient'
+import { fetchSingleNyTimesArticle } from '../client/nytimesClient'
 import { convertGuardianSingleItemToArticle } from '../util/guardianUtil'
 import { convertNewsApiEverythingResToAritcle } from '../util/newsApiUtil'
+import { convertNyTimesSearchResToAritcle } from '../util/nytimesUtil'
 import { queryKeys } from '../util/queryKeys'
-import { Article, SingleArticleResponse } from '@/types'
+import { Article, SingleArticleResponse, SingleArticleResponsePromises } from '@/types'
 import { GuardianSingleItem } from '@/types/GuardianApiTypes'
 import { NewApiResponse } from '@/types/NewsApiTypes'
+import { NyTimesResponse as NyTimesResponse } from '@/types/NyTimesApiTypes'
 import { NewsSource } from '@/util/constants'
+
+const getQueryFn = (api: NewsSource, id: string): (() => SingleArticleResponsePromises) => {
+   switch (api) {
+      case NewsSource.NewsApi:
+         return () => fetchSingleNewsApiArticle(id)
+      case NewsSource.Guardian:
+         return () => fetchSingleGuardianArticle(id)
+      default:
+         return () => fetchSingleNyTimesArticle(id)
+   }
+}
+
+const convertSingleArticle = (api: NewsSource, data: SingleArticleResponse): Article => {
+   switch (api) {
+      case NewsSource.Guardian:
+         return convertGuardianSingleItemToArticle(data as GuardianSingleItem)
+      case NewsSource.NewsApi:
+         return convertNewsApiEverythingResToAritcle(data as NewApiResponse)[0]
+      default:
+         return convertNyTimesSearchResToAritcle(data as NyTimesResponse)[0]
+   }
+}
 
 // fetching single article from correct api using id
 export const useSingleArticleData = ({ api, id }: { api: NewsSource; id: string }) => {
    return useQuery<SingleArticleResponse, unknown, Article>({
       queryKey: [queryKeys.singleArticle, api, id],
-      queryFn: () =>
-         api === NewsSource.Guardian
-            ? fetchSingleGuardianArticle(id)
-            : fetchSingleNewsApiArticle(id),
+      queryFn: getQueryFn(api, id),
       enabled: !!api && !!id,
-      // converts to Article
-      select: (data) =>
-         api === NewsSource.Guardian
-            ? convertGuardianSingleItemToArticle(data as GuardianSingleItem)
-            : (convertNewsApiEverythingResToAritcle(data as NewApiResponse)[0] as Article)
+      select: (data) => convertSingleArticle(api, data)
    })
 }

--- a/src/api/queries/useTopStoriesData.ts
+++ b/src/api/queries/useTopStoriesData.ts
@@ -2,13 +2,16 @@ import { UseQueryOptions, useQueries } from '@tanstack/react-query'
 
 import { fetchGuardianTopStories } from '../client/guardianClient'
 import { fetchNewsApiTopStories } from '../client/newsApiClient'
+import { fetchNyTimesTopStories } from '../client/nytimesClient'
 import { convertGuardianContentToArticle } from '../util/guardianUtil'
 import { convertNewsApiEverythingResToAritcle } from '../util/newsApiUtil'
+import { convertNyTimesSearchResToAritcle } from '../util/nytimesUtil'
 import { queryKeys } from '../util/queryKeys'
 import { Article, ContentResponse } from '@/types'
 import { GuardianContentResponse } from '@/types/GuardianApiTypes'
 import { NewApiResponse } from '@/types/NewsApiTypes'
-import { NewsSource, defaultSources } from '@/util/constants'
+import { NyTimesResponse } from '@/types/NyTimesApiTypes'
+import { NewsSource, TOP_STORIES_STALE_TIME, defaultSources } from '@/util/constants'
 
 // top stories parallel dynamic queries
 export const useTopStoriesData = () => {
@@ -22,7 +25,7 @@ export const useTopStoriesData = () => {
                      queryKey: [queryKeys.newsApiTopStories],
                      queryFn: () => fetchNewsApiTopStories(),
                      select: (data) => convertNewsApiEverythingResToAritcle(data as NewApiResponse),
-                     staleTime: 3600000
+                     staleTime: TOP_STORIES_STALE_TIME
                   }
 
                case NewsSource.Guardian:
@@ -32,7 +35,16 @@ export const useTopStoriesData = () => {
                      queryFn: () => fetchGuardianTopStories(),
                      select: (data) =>
                         convertGuardianContentToArticle(data as GuardianContentResponse),
-                     staleTime: 3600000
+                     staleTime: TOP_STORIES_STALE_TIME
+                  }
+
+               case NewsSource.NyTimes:
+                  // news api
+                  return {
+                     queryKey: [queryKeys.nytimesTopStories],
+                     queryFn: () => fetchNyTimesTopStories(),
+                     select: (data) => convertNyTimesSearchResToAritcle(data as NyTimesResponse),
+                     staleTime: TOP_STORIES_STALE_TIME
                   }
 
                default:

--- a/src/api/util/nytimesUtil.ts
+++ b/src/api/util/nytimesUtil.ts
@@ -2,7 +2,7 @@ import { format, subDays } from 'date-fns'
 import qs from 'qs'
 
 import { Article, ContentParams } from '@/types'
-import { NYTimesResponse, NyTimesEverythingParams } from '@/types/NyTimesApiTypes'
+import { NyTimesResponse, NyTimesSearchParams } from '@/types/NyTimesApiTypes'
 import { NewsSource } from '@/util/constants'
 
 const NY_TIMES_API_KEY = import.meta.env.VITE_NY_TIMES_API_KEY
@@ -45,7 +45,7 @@ export const parseToNyTimesParams = ({
 }: ContentParams) => {
    const categoriesToQ = categories?.join(' OR ') ?? ''
 
-   const params: NyTimesEverythingParams = {
+   const params: NyTimesSearchParams = {
       q: `${search ? search : ''}${categoriesToQ ? `${categoriesToQ}` : ''}`.slice(0, 500), //max length 500,
       page: page,
       end_date: date ? format(date, 'yyyy-MM-dd') : undefined,
@@ -58,7 +58,7 @@ export const parseToNyTimesParams = ({
 
 // returns params when doing single item search via /articlesearch api
 export const parseToSingleNyTimesParams = (id: string) => {
-   const query: NyTimesEverythingParams = {
+   const query: NyTimesSearchParams = {
       q: id,
       'api-key': NY_TIMES_API_KEY
    }
@@ -67,7 +67,7 @@ export const parseToSingleNyTimesParams = (id: string) => {
 
 // return news api params for topstories
 export const parseToTopStoriesNyTimesParams = () => {
-   const query: NyTimesEverythingParams = {
+   const query: NyTimesSearchParams = {
       q: nyTimesCategories.join(' OR '), // combining all categorie
       begin_date: format(subDays(new Date(), 30), 'yyyy-MM-dd'), // yesterday
       end_date: format(new Date(), 'yyyy-MM-dd'), // today
@@ -77,16 +77,18 @@ export const parseToTopStoriesNyTimesParams = () => {
 }
 
 // converts news api response to common Article type
-export const convertNyTimesEverythingResToAritcle = (data: NYTimesResponse): Article[] => {
-   return data.response.docs.map((article) => ({
-      id: article.headline.main,
-      api: NewsSource.NyTimes,
-      author: article.byline.person[0]?.firstname + (article.byline.person[0]?.lastname ?? ''),
-      content: article.lead_paragraph,
-      date: article.pub_date,
-      title: article.headline.main,
-      imageUrl: article.multimedia[0]?.url,
-      source: article.source,
-      fullStory: article.web_url
-   }))
+export const convertNyTimesSearchResToAritcle = (data: NyTimesResponse): Article[] => {
+   return data.response.docs.map(
+      ({ headline, byline, lead_paragraph, pub_date, multimedia, source, web_url }) => ({
+         id: headline.main,
+         api: NewsSource.NyTimes,
+         author: byline.person[0]?.firstname + (byline.person[0]?.lastname ?? ''),
+         content: lead_paragraph,
+         date: pub_date,
+         title: headline.main,
+         imageUrl: multimedia[0]?.url ? `https://www.nytimes.com/${multimedia[0]?.url}` : '',
+         source: source,
+         fullStory: web_url
+      })
+   )
 }

--- a/src/api/util/nytimesUtil.ts
+++ b/src/api/util/nytimesUtil.ts
@@ -1,0 +1,92 @@
+import { format, subDays } from 'date-fns'
+import qs from 'qs'
+
+import { Article, ContentParams } from '@/types'
+import { NYTimesResponse, NyTimesEverythingParams } from '@/types/NyTimesApiTypes'
+import { NewsSource } from '@/util/constants'
+
+const NY_TIMES_API_KEY = import.meta.env.VITE_NY_TIMES_API_KEY
+export const nyTimesCategories = [
+   'arts',
+   'automobiles',
+   'books / review',
+   'business',
+   'fashion',
+   'food',
+   'health',
+   'home',
+   'insider',
+   'magazine',
+   'movies',
+   'nyregion',
+   'obituaries',
+   'opinion',
+   'politics',
+   'realestate',
+   'science',
+   'sports',
+   'sundayreview',
+   'technology',
+   'theater',
+   't - magazine',
+   'travel',
+   'upshot',
+   'us',
+   'world'
+]
+
+// converts params to params for ny times
+export const parseToNyTimesParams = ({
+   search,
+   categories,
+   date,
+   fromDate,
+   page
+}: ContentParams) => {
+   const categoriesToQ = categories?.join(' OR ') ?? ''
+
+   const params: NyTimesEverythingParams = {
+      q: `${search ? search : ''}${categoriesToQ ? `${categoriesToQ}` : ''}`.slice(0, 500), //max length 500,
+      page: page,
+      end_date: date ? format(date, 'yyyy-MM-dd') : undefined,
+      begin_date: fromDate ? format(fromDate, 'yyyy-MM-dd') : undefined,
+      'api-key': NY_TIMES_API_KEY
+   }
+
+   return qs.stringify(params)
+}
+
+// returns params when doing single item search via /articlesearch api
+export const parseToSingleNyTimesParams = (id: string) => {
+   const query: NyTimesEverythingParams = {
+      q: id,
+      'api-key': NY_TIMES_API_KEY
+   }
+   return qs.stringify(query)
+}
+
+// return news api params for topstories
+export const parseToTopStoriesNyTimesParams = () => {
+   const query: NyTimesEverythingParams = {
+      q: nyTimesCategories.join(' OR '), // combining all categorie
+      begin_date: format(subDays(new Date(), 30), 'yyyy-MM-dd'), // yesterday
+      end_date: format(new Date(), 'yyyy-MM-dd'), // today
+      'api-key': NY_TIMES_API_KEY
+   }
+   return qs.stringify(query)
+}
+
+// converts news api response to common Article type
+export const convertNyTimesEverythingResToAritcle = (data: NYTimesResponse): Article[] => {
+   return data.response.docs.map((article) => ({
+      id: article.headline.main,
+      api: NewsSource.NyTimes,
+      author: article.byline.person[0]?.firstname + (article.byline.person[0]?.lastname ?? ''),
+      content: article.lead_paragraph,
+      date: article.pub_date,
+      title: article.headline.main,
+      imageUrl: article.multimedia[0]?.url,
+      source: article.source,
+      fullStory: article.web_url
+   }))
+}

--- a/src/api/util/queryKeys.ts
+++ b/src/api/util/queryKeys.ts
@@ -2,10 +2,13 @@
 export const queryKeys = {
    newsApiContent: 'newsapi-content',
    guardianContent: 'guardian-content',
+   nytimesContent: 'nytimes-content',
    categories: 'categories',
    singleArticle: 'single-article',
    newsApiTopStories: 'newsapi-top-stories',
    guardianTopStories: 'guardian-top-stories',
+   nytimesTopStories: 'nytimes-top-stories',
    newsApiPersonalFeed: 'newsapi-personal-feed',
-   guardianPersonalFeed: 'guardian-personal-feed'
+   guardianPersonalFeed: 'guardian-personal-feed',
+   nytimesPersonalFeed: 'nytimes-personal-feed'
 }

--- a/src/types/NyTimesApiTypes.ts
+++ b/src/types/NyTimesApiTypes.ts
@@ -1,5 +1,5 @@
 // Root response type
-export type NYTimesResponse = {
+export type NyTimesResponse = {
    status: string
    copyright: string
    response: {
@@ -95,7 +95,7 @@ type Person = {
    rank: number
 }
 
-export interface NyTimesEverythingParams {
+export interface NyTimesSearchParams {
    'api-key': string
    q?: string
    begin_date?: string

--- a/src/types/NyTimesApiTypes.ts
+++ b/src/types/NyTimesApiTypes.ts
@@ -1,0 +1,104 @@
+// Root response type
+export type NYTimesResponse = {
+   status: string
+   copyright: string
+   response: {
+      docs: NyTimesArticle[]
+   }
+}
+
+// Article type
+export type NyTimesArticle = {
+   abstract: string
+   web_url: string
+   snippet: string
+   lead_paragraph: string
+   source: string
+   multimedia: Multimedia[]
+   headline: Headline
+   keywords: Keyword[]
+   pub_date: string
+   document_type: string
+   news_desk: string
+   section_name: string
+   subsection_name?: string
+   byline: Byline
+   type_of_material: string
+   _id: string
+   word_count: number
+   uri: string
+}
+
+// Multimedia type
+type Multimedia = {
+   rank: number
+   subtype: string
+   caption: string | null
+   credit: string | null
+   type: string
+   url: string
+   height: number
+   width: number
+   legacy: LegacyData
+   subType: string
+   crop_name: string
+}
+
+// LegacyData type
+type LegacyData = {
+   xlarge?: string
+   xlargewidth?: number
+   xlargeheight?: number
+   thumbnail?: string
+   thumbnailwidth?: number
+   thumbnailheight?: number
+   wide?: string
+   widewidth?: number
+   wideheight?: number
+}
+
+// Headline type
+type Headline = {
+   main: string
+   kicker: string | null
+   content_kicker: string | null
+   print_headline: string | null
+   name: string | null
+   seo: string | null
+   sub: string | null
+}
+
+// Keyword type
+type Keyword = {
+   name: string
+   value: string
+   rank: number
+   major: string
+}
+
+// Byline type
+type Byline = {
+   original: string
+   person: Person[]
+   organization: string | null
+}
+
+// Person type
+type Person = {
+   firstname: string
+   middlename: string | null
+   lastname: string
+   qualifier: string | null
+   title: string | null
+   role: string
+   organization: string
+   rank: number
+}
+
+export interface NyTimesEverythingParams {
+   'api-key': string
+   q?: string
+   begin_date?: string
+   end_date?: string | undefined
+   page?: number
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import { GuardianContentResponse, GuardianSingleItem } from './GuardianApiTypes'
 import { NewApiResponse } from './NewsApiTypes'
-import { NYTimesResponse } from './NyTimesApiTypes'
+import { NyTimesResponse } from './NyTimesApiTypes'
 import { NewsSource } from '@/util/constants'
 
 /* 
@@ -17,8 +17,12 @@ export interface ContentParams {
 }
 
 // unionised for all apis to use in use query custom hooks
-export type ContentResponse = NewApiResponse | GuardianContentResponse | NYTimesResponse
-export type SingleArticleResponse = GuardianSingleItem | NewApiResponse | NYTimesResponse
+export type ContentResponse = NewApiResponse | GuardianContentResponse | NyTimesResponse
+export type SingleArticleResponse = GuardianSingleItem | NewApiResponse | NyTimesResponse
+export type SingleArticleResponsePromises =
+   | Promise<GuardianSingleItem>
+   | Promise<NewApiResponse>
+   | Promise<NyTimesResponse>
 
 // common Article type for WhatsNews
 export interface Article {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import { GuardianContentResponse, GuardianSingleItem } from './GuardianApiTypes'
 import { NewApiResponse } from './NewsApiTypes'
+import { NYTimesResponse } from './NyTimesApiTypes'
 import { NewsSource } from '@/util/constants'
 
 /* 
@@ -16,8 +17,8 @@ export interface ContentParams {
 }
 
 // unionised for all apis to use in use query custom hooks
-export type ContentResponse = NewApiResponse | GuardianContentResponse
-export type SingleArticleResponse = GuardianSingleItem | NewApiResponse
+export type ContentResponse = NewApiResponse | GuardianContentResponse | NYTimesResponse
+export type SingleArticleResponse = GuardianSingleItem | NewApiResponse | NYTimesResponse
 
 // common Article type for WhatsNews
 export interface Article {

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -10,11 +10,16 @@ export const newsSourceLabels = {
    [NewsSource.NyTimes]: 'New York Times'
 }
 
-export const defaultSources: string[] = [NewsSource.NewsApi, NewsSource.Guardian]
+export const defaultSources: string[] = [
+   NewsSource.NewsApi,
+   NewsSource.Guardian,
+   NewsSource.NyTimes
+]
 
 // numeric constants
 export const PAGE_SIZE_PER_REQUEST = 10
 export const PAGE_SIZE_FOR_TOP_STORIES = 20
+export const TOP_STORIES_STALE_TIME = 3600000
 
 // tabs
 export enum HomeTab {

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,11 +1,13 @@
 // news sources
 export enum NewsSource {
    NewsApi = 'newsapi',
-   Guardian = 'guardian'
+   Guardian = 'guardian',
+   NyTimes = 'nytimes'
 }
 export const newsSourceLabels = {
    [NewsSource.NewsApi]: 'News Api',
-   [NewsSource.Guardian]: 'Guardian'
+   [NewsSource.Guardian]: 'Guardian',
+   [NewsSource.NyTimes]: 'New York Times'
 }
 
 export const defaultSources: string[] = [NewsSource.NewsApi, NewsSource.Guardian]


### PR DESCRIPTION
# Description
The New York Times api has been integrated - https://developer.nytimes.com/docs/articlesearch-product/1/overview


Following steps were taken to extend the existing implementation
- A new news source added in `constants.ts` to the `NewsSource` `enum`
- `api/`
  - `api/client/nytimesClient` - fetcher functions 
  - `api/util/nytimesUtil` - util functions for parsing data in 
  - `api/queries/` 
    - custom hooks wrapped around `react-query` hooks have been extended to use ny times api in `api/queries`
    - query-keys for react queries updated in `queryKeys.ts`
- `types/`
  - `NyTimesTypes` added with type declarations for raw api responses and params
- `VITE_NY_TIMES_API_KEY` added in `.env`